### PR TITLE
CLI for training lab 5.

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -2001,7 +2001,70 @@ def shutdown(ctx, interface_name):
         else:
             config_db.mod_entry("PORTCHANNEL", interface_name, {"admin_status": "down"})
 
+##
+# 'tx_error_threshold' subgroup
 #
+
+@interface.group()
+@click.pass_context
+def tx_error_threshold(ctx):
+    """Set or del threshold of tx error statistics"""
+    pass
+
+#
+# 'set' subcommand
+#
+@tx_error_threshold.command()
+@click.pass_context
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('interface_tx_err_threshold', metavar='<interface_tx_err_threshold>', required=True, type=int)
+def set(ctx, interface_name, interface_tx_err_threshold):
+    """Set threshold of tx error statistics"""
+    if interface_name is None:
+        ctx.fail("'interface_name' is None!")
+
+    config_db = ctx.obj['config_db']
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    if interface_name_is_valid(config_db, interface_name) is False:
+        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+
+    if interface_name.startswith("Ethernet"):
+        config_db.set_entry("TX_ERR_CFG", (interface_name), {"tx_error_threshold": interface_tx_err_threshold})
+    else:
+        ctx.fail("Only Ethernet interfaces are supported")
+
+#
+# 'clear' subcommand
+#
+@tx_error_threshold.command()
+@click.pass_context
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+def clear(ctx, interface_name):
+    """Clear threshold of tx error statistics"""
+    if interface_name is None:
+        ctx.fail("'interface_name' is None!")
+
+    config_db = ctx.obj["config_db"]
+    if get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(interface_name)
+        if interface_name is None:
+            ctx.fail("'interface_name' is None!")
+
+    if interface_name_is_valid(config_db, interface_name) is False:
+        ctx.fail("Interface name is invalid. Please enter a valid interface name!!")
+
+    if config_db.get_entry('TX_ERR_CFG', interface_name):
+        if interface_name.startswith("Ethernet"):
+            config_db.set_entry("TX_ERR_CFG", (interface_name), None)
+        else:
+            ctx.fail("Only Ethernet interfaces are supported")
+    else:
+        ctx.fail("Tx Error threshold hasn't been configured on the interface")
+
 # 'speed' subcommand
 #
 
@@ -3348,6 +3411,17 @@ def feature_autorestart(name, autorestart):
 
     for ns, cfgdb in cfgdb_clients.items():
         cfgdb.mod_entry('FEATURE', name, {'auto_restart': autorestart})
+
+#
+# 'tx_error_stat_poll_period' subcommand ('config tx_error_stat_poll_period')
+#
+@config.command()
+@click.argument('period', metavar='<period>', required=True, type=int)
+def tx_error_stat_poll_period(period):
+    """Set polling period of tx error statistics, 0 for disable, xxx for default"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    config_db.set_entry("TX_ERR_CFG", ("GLOBAL_PERIOD"), {"tx_error_check_period": period})
 
 if __name__ == '__main__':
     config()

--- a/show/main.py
+++ b/show/main.py
@@ -846,6 +846,42 @@ def status(interfacename, namespace, display, verbose):
         cmd += " -n {}".format(namespace)
     run_command(cmd, display_cmd=verbose)
 
+@interfaces.command()
+@click.argument('interfacename', required=False)
+def tx_error(interfacename):
+    """Show Interface tx_error information"""
+  
+    state_db = SonicV2Connector(host='127.0.0.1')
+    state_db.connect(state_db.STATE_DB, False)   # Make one attempt only
+    TABLE_NAME_SEPARATOR = '|'
+    prefix_statedb = "TX_ERR_STATE_TABLE|"
+    _hash = '{}{}'.format(prefix_statedb, '*')
+    # DBInterface keys() method
+    txerr_keys = state_db.keys(state_db.STATE_DB, _hash)
+    if txerr_keys is not None:
+        appl_db = SonicV2Connector(host='127.0.0.1')
+        appl_db.connect(appl_db.APPL_DB, False)
+        prefix_appldb = "TX_ERR_APPL:"
+        _hash = '{}{}'.format(prefix_statedb, "*")
+        txerr_appl_keys = appl_db.keys(appl_db.APPL_DB, _hash)
+        table = []
+        for k in txerr_keys:
+            k = k.replace(prefix_statedb, "") 
+            r = []
+            r.append(k)
+    
+            r.append(state_db.get(state_db.STATE_DB, prefix_statedb + k, "tx_status"))
+            entry = appl_db.get_all(appl_db.APPL_DB, prefix_appldb + k)
+            if 'tx_error_stati' not in entry:
+                r.append("")
+            else:
+                r.append(entry['tx_error_stati'])
+    
+            table.append(r)
+    
+        header = ['Port', 'status', 'statistics']
+        click.echo(tabulate(table, header))
+
 
 # 'counters' subcommand ("show interfaces counters")
 @interfaces.group(invoke_without_command=True)


### PR DESCRIPTION
Signed-off-by: Raphael Tryster <raphaelt@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

What I did

Implemented a solution for Lab 5 in SONiC training based on one of the solutions provided in the Wiki, with some changes. These include using the counters DB instead of calls to SAI to retrieve the tx error counter, passing the statistics data by reference so that the difference between successive counter readings would be used correctly, and added python code to handle some not found conditions.

Why I did it

I used a prepared solution, studied it with gdb and modified it based on what I observed in gdb, because so much of the way code is written in C++ is unfamiliar that I expected writing from scratch would take an order of magnitude more than the time allotted, and I would get more benefit from studying and modifying existing code.

How I verified it

Configure polling period, e.g.

sudo config tx_error_stat_poll_period 30

Configure error threshold, e.g.

sudo config interface tx_error_threshold set Ethernet0 10

Disable automatic refresh of counters, so that counter values can be injected into DB and stay there:

counterpoll port disable

Lookup OID of port being tested, e.g.

redis-cli -n 2 hgetall "COUNTERS_PORT_NAME_MAP" | grep -A1 "Ethernet0"
Ethernet0
oid:0x10000000008d4

Inject tx errors to that port and verify that DB was updated:

redis-cli -n 2 hset "COUNTERS:oid:0x10000000008d4" "SAI_PORT_STAT_IF_OUT_ERRORS" "20"
(integer) 0
redis-cli -n 2 hget "COUNTERS:oid:0x10000000008d4" "SAI_PORT_STAT_IF_OUT_ERRORS"
"20"

Show status within the poll period:

show interfaces tx_error
Port status statistics

Ethernet0 error 20

Show status after the poll period:

show interfaces tx_error
Port status statistics

Ethernet0 ok 20

Repeat sequences of the above commands to verify that status becomes error when the delta exceeds the threshold, and ok when it doesn't.

Details if related